### PR TITLE
Preferences.java

### DIFF
--- a/app/src/main/java/com/restart/spacestationtracker/Preferences.java
+++ b/app/src/main/java/com/restart/spacestationtracker/Preferences.java
@@ -158,7 +158,7 @@ public class Preferences extends AppCompatActivity {
          * @return True if permission is granted. False if otherwise.
          */
         public boolean isLocationPermissionGranted() {
-            return Build.VERSION.SDK_INT >= 23 && mContext.checkSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+            return Build.VERSION.SDK_INT <= Build.VERSION_CODES.M || mContext.checkSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
         }
 
         /**


### PR DESCRIPTION
Stops crashing in API 23 and below while Checking the ISS notifications. Permission check is still done for API 23 and above.